### PR TITLE
feat(documentstore): hook existing documents after roslyn is initialised

### DIFF
--- a/lua/rzls/documentstore.lua
+++ b/lua/rzls/documentstore.lua
@@ -21,8 +21,6 @@ local virtual_suffixes = {
 ---@type rzls.VirtualDocument<string, table<razor.LanguageKind, rzls.VirtualDocument>>
 local virtual_documents = {}
 
-local roslyn_ready = false
-
 ---@param name string
 ---@return number | nil
 local function buffer_with_name(name)
@@ -102,59 +100,28 @@ end
 ---@param uri string
 ---@param _version integer
 ---@param type razor.LanguageKind
----@return rzls.VirtualDocument
+---@return rzls.VirtualDocument | nil
 function M.get_virtual_document(uri, _version, type)
-    return virtual_documents[uri_to_path(uri)][type]
+    local doc = virtual_documents[uri_to_path(uri)]
+    return doc and doc[type]
 end
 
-local document_generation_initialized = false
-
 ---@param client vim.lsp.Client
-function M.initialize(client, root_dir)
-    if not roslyn_ready or document_generation_initialized then
-        return
-    end
-
-    document_generation_initialized = true
-
-    local razor_files = vim.fs.find(function(name)
-        return name:match(".*%.razor$")
-    end, {
-        type = "file",
-        limit = math.huge,
-        path = root_dir,
-    })
-
-    local opened_documents = vim.tbl_keys(virtual_documents)
-    for _, razor_file in ipairs(razor_files) do
-        if not vim.tbl_contains(opened_documents, razor_file) then
-            local razor_buf = get_or_create_buffer_for_filepath(razor_file, "razor")
-            vim.api.nvim_buf_call(razor_buf, vim.cmd.edit)
-        end
-    end
-
+function M.initialize(client)
     local pipe_name = utils.uuid()
 
-    ---@type rzls.ProjectedDocument
-    local virtual_document = vim.tbl_values(virtual_documents)[1]
-
     local function initialize_roslyn()
-        local initialized = vim.lsp.buf_notify(virtual_document.buf, "razor/initialize", {
+        local roslyn_client = vim.lsp.get_clients({ name = "roslyn" })[1]
+        roslyn_client.notify("razor/initialize", {
             pipeName = pipe_name,
         })
-
-        -- Roslyn might not have been initialized yet. Repeat every seconds until
-        -- we can send the notification
-        if not initialized then
-            local timer = vim.uv.new_timer()
-            timer:start(1000, 0, initialize_roslyn)
-            return
-        end
 
         client.notify("razor/namedPipeConnect", {
             pipeName = pipe_name,
         })
     end
+
+    vim.notify("Connected to roslyn via pipe:" .. pipe_name)
 
     initialize_roslyn()
 end

--- a/lua/rzls/documentstore.lua
+++ b/lua/rzls/documentstore.lua
@@ -106,9 +106,10 @@ function M.get_virtual_document(uri, _version, type)
     return doc and doc[type]
 end
 
+local pipe_name
 ---@param client vim.lsp.Client
 function M.initialize(client)
-    local pipe_name = utils.uuid()
+    pipe_name = utils.uuid()
 
     local function initialize_roslyn()
         local roslyn_client = vim.lsp.get_clients({ name = "roslyn" })[1]
@@ -129,6 +130,9 @@ end
 local state = {
     get_docstore = function()
         return virtual_documents
+    end,
+    get_roslyn_pipe = function()
+        return pipe_name
     end,
 }
 

--- a/lua/rzls/health.lua
+++ b/lua/rzls/health.lua
@@ -1,5 +1,6 @@
 local M = {}
 local razor = require("rzls.razor")
+
 M.check = function()
     vim.health.start("rzls.nvim report")
     -- make sure setup function parameters are ok
@@ -25,7 +26,13 @@ M.check = function()
             end
         end
     end
-    -- make sure setup function parameters are ok
-    vim.health.ok("rzls.nvim report")
+
+    local roslyn_pipe_id = require("rzls.documentstore").get_roslyn_pipe
+
+    if roslyn_pipe_id then
+        vim.health.ok("roslyn lsp connected via pipe: " .. roslyn_pipe_id)
+    else
+        vim.health.error("roslyn pipe not connected")
+    end
 end
 return M

--- a/lua/rzls/init.lua
+++ b/lua/rzls/init.lua
@@ -66,13 +66,17 @@ function M.setup(config)
                     "true",
                 },
                 on_init = function(client, _initialize_result)
-                    M.load_existing_files(root_dir)
+                    M.load_existing_files(client.root_dir)
+                    vim.api.nvim_create_autocmd("User", {
+                        pattern = "RoslynInitialized",
+                        callback = function()
+                            documentstore.initialize(client)
+                        end,
+                    })
                     M.watch_new_files(root_dir)
-                    documentstore.initialize(client, root_dir)
                 end,
                 root_dir = root_dir,
                 on_attach = function(client, bufnr)
-                    documentstore.initialize(client, root_dir)
                     documentstore.register_vbufs(bufnr)
                     rzlsconfig.on_attach(client, bufnr)
                 end,
@@ -120,4 +124,5 @@ function M.watch_new_files(path)
         end
     end)
 end
+
 return M

--- a/lua/rzls/init.lua
+++ b/lua/rzls/init.lua
@@ -72,6 +72,7 @@ function M.setup(config)
                         callback = function()
                             documentstore.initialize(client)
                         end,
+                        group = au,
                     })
                     M.watch_new_files(root_dir)
                 end,

--- a/lua/rzls/roslyn_handlers.lua
+++ b/lua/rzls/roslyn_handlers.lua
@@ -1,6 +1,7 @@
 local documentstore = require("rzls.documentstore")
 local razor = require("rzls.razor")
 
+---@module "nio"
 ---@param _err lsp.ResponseError
 ---@param result razor.ProvideDynamicFileParams
 ---@param _ctx lsp.HandlerContext

--- a/lua/rzls/roslyn_handlers.lua
+++ b/lua/rzls/roslyn_handlers.lua
@@ -12,6 +12,9 @@ local function roslyn_razor_provideDynamicFileHandler(_err, result, _ctx, _confi
         return nil, vim.lsp.rpc.rpc_response_error(-32602, "Missing razorDocument")
     end
     local vd = documentstore.get_virtual_document(result.razorDocument.uri, 0, razor.language_kinds.csharp)
+    if not vd then
+        return nil, vim.lsp.rpc.rpc_response_error(-32600, "Could not find requested document")
+    end
     local bufnr = vd.buf
 
     if bufnr == nil then
@@ -22,7 +25,6 @@ local function roslyn_razor_provideDynamicFileHandler(_err, result, _ctx, _confi
     -- TODO: ideally we could get the client by the razor document, but the client might no have been attached yet
     local razor_client = vim.lsp.get_clients({ name = "rzls" })[1]
     assert(razor_client, "Could not find razor client")
-    documentstore.rosyln_is_ready(razor_client)
 
     return {
         csharpDocument = {


### PR DESCRIPTION
Opens the existing docs based on a UserCommand from roslyn.nvim

blocked by https://github.com/seblj/roslyn.nvim/pull/69