### PR TITLE
feat(diagnostics): add csharpPullDiagnostics

### DIFF
--- a/lua/rzls/handlers/csharppulldiagnostics.lua
+++ b/lua/rzls/handlers/csharppulldiagnostics.lua
@@ -1,0 +1,39 @@
+local documentstore = require("rzls.documentstore")
+local razor = require("rzls.razor")
+
+---@param _err lsp.ResponseError
+---@param result lsp.DocumentDiagnosticParams
+---@param _ctx lsp.HandlerContext
+---@param _config table
+return function(_err, result, _ctx, _config)
+    local virtual_document = documentstore.get_virtual_document(
+        result.textDocument.uri,
+        result._razor_hostDocumentVersion,
+        razor.language_kinds.csharp
+    )
+    assert(virtual_document, "csharp document was not found")
+
+    local virtual_client = virtual_document:get_lsp_client()
+    assert(virtual_client, "Could not find LSP client for virtual document")
+
+    ---@type lsp.DocumentDiagnosticParams
+    local diagnostic_params = vim.tbl_deep_extend("force", result, {
+        textDocument = {
+            uri = vim.uri_from_bufnr(virtual_document.buf),
+        },
+    })
+
+    local diagnostic_response = virtual_client.request_sync(
+        vim.lsp.protocol.Methods.textDocument_diagnostic,
+        diagnostic_params,
+        nil,
+        virtual_document.buf
+    )
+    assert(diagnostic_response)
+
+    if diagnostic_response.err then
+        return nil, diagnostic_response.err
+    end
+
+    return diagnostic_response.result
+end

--- a/lua/rzls/handlers/csharppulldiagnostics.lua
+++ b/lua/rzls/handlers/csharppulldiagnostics.lua
@@ -1,6 +1,8 @@
 local documentstore = require("rzls.documentstore")
 local razor = require("rzls.razor")
 
+local empty_response = {}
+
 ---@param _err lsp.ResponseError
 ---@param result lsp.DocumentDiagnosticParams
 ---@param _ctx lsp.HandlerContext
@@ -8,6 +10,7 @@ local razor = require("rzls.razor")
 return function(_err, result, _ctx, _config)
     local virtual_document = documentstore.get_virtual_document(
         result.textDocument.uri,
+        ---@diagnostic disable-next-line: undefined-field
         result._razor_hostDocumentVersion,
         razor.language_kinds.csharp
     )
@@ -29,7 +32,9 @@ return function(_err, result, _ctx, _config)
         nil,
         virtual_document.buf
     )
-    assert(diagnostic_response)
+    if not diagnostic_response then
+        return empty_response
+    end
 
     if diagnostic_response.err then
         return nil, diagnostic_response.err

--- a/lua/rzls/handlers/init.lua
+++ b/lua/rzls/handlers/init.lua
@@ -2,7 +2,7 @@ local documentstore = require("rzls.documentstore")
 local razor = require("rzls.razor")
 
 local not_implemented = function(err, result, ctx, config)
-    vim.print("Called" .. ctx.method)
+    vim.print("Called " .. ctx.method)
     vim.print(vim.inspect(err))
     vim.print(vim.inspect(result))
     vim.print(vim.inspect(ctx))
@@ -65,7 +65,7 @@ return {
     ["razor/references"] = not_implemented,
 
     -- Called to get C# diagnostics from Roslyn when publishing diagnostics for VS Code
-    ["razor/csharpPullDiagnostics"] = not_implemented,
+    ["razor/csharpPullDiagnostics"] = require("rzls.handlers.csharppulldiagnostics"),
     ["textDocument/colorPresentation"] = not_supported,
     ["razor/completion"] = require("rzls.handlers.completion"),
 }

--- a/lua/rzls/handlers/providesemantictokensrange.lua
+++ b/lua/rzls/handlers/providesemantictokensrange.lua
@@ -1,7 +1,9 @@
 local documentstore = require("rzls.documentstore")
 local razor = require("rzls.razor")
+
 ---@type number[]
 local empty_response = {}
+
 ---@param _err lsp.ResponseError
 ---@param result razor.ProvideSemanticTokensParams
 ---@param _ctx lsp.HandlerContext

--- a/lua/rzls/init.lua
+++ b/lua/rzls/init.lua
@@ -66,7 +66,7 @@ function M.setup(config)
                     rzlsconfig.path,
                     "--logLevel",
                     "0",
-                    "--DelegateToCSharpOnDiagnosticsPublish",
+                    "--DelegateToCSharpOnDiagnosticPublish",
                     "true",
                     "--UpdateBuffersForClosedDocuments",
                     "true",
@@ -124,10 +124,8 @@ function M.setup(config)
                 end,
                 capabilities = vim.tbl_deep_extend("force", rzlsconfig.capabilities, extraCapabilities),
                 settings = {
-                    ["razor.server.trace"] = "Trace",
                     html = vim.empty_dict(),
                     razor = vim.empty_dict(),
-                    ["vs.editor.razor"] = vim.empty_dict(),
                 },
                 handlers = handlers,
             })

--- a/lua/rzls/razor.lua
+++ b/lua/rzls/razor.lua
@@ -99,6 +99,8 @@ local razor_highlights = {
     ["@lsp.type.razorDirectiveAttribute"] = { link = "Keyword" },
     ["@lsp.type.field"] = { link = "@variable" },
     ["@lsp.type.variable.razor"] = { link = "@variable" },
+    ["@lsp.type.razorComponentElement.razor"] = { link = "@lsp.type.class" },
+    ["@lsp.type.razorTagHelperElement.razor"] = { link = "@lsp.type.class" },
 }
 
 M.apply_highlights = function()


### PR DESCRIPTION
Fixed diagnostics based on the `razor/csharpPullDiagnostics`. This method was not being called before because of a typo in the `rzls` on the `--DelegateToCSharpOnDiagnosticsPublish` argument.

But this is only half of it, you also need to pass `--razorSourceGenerator` and `--razorDesignTimePath` as arguments to Roslyn. I did that with the following config:

```lua
local rzls_path = vim.fs.joinpath(require('mason-registry').get_package('rzls'):get_install_path(), 'libexec')

require('roslyn').setup {
  filewatching = false,
  capabilities = capabilities,
  args = {
    '--logLevel=Information',
    '--extensionLogDirectory=' .. vim.fs.dirname(vim.lsp.get_log_path()),
    '--razorSourceGenerator=' .. vim.fs.joinpath(rzls_path, 'Microsoft.CodeAnalysis.Razor.Compiler.dll'),
    '--razorDesignTimePath=' .. vim.fs.joinpath(rzls_path, 'Targets', 'Microsoft.NET.Sdk.Razor.DesignTime.targets'),
  },
  config = {
    handlers = require 'rzls.roslyn_handlers',
  },
}
```

Should we add something to `rzls.nvim` to help passing those arguments?

Anyways, here are some screenshots of the diagnostics working 😄 .
![razor diagnostics](https://github.com/user-attachments/assets/9bf44d2c-d77a-4290-bf6e-74afc573e473)
