### PR TITLE
feat: support textDocument/documentColor

### DIFF
--- a/lua/rzls/handlers/init.lua
+++ b/lua/rzls/handlers/init.lua
@@ -44,7 +44,7 @@ return {
     ["razor/provideCodeActions"] = not_implemented,
     ["razor/resolveCodeActions"] = not_implemented,
     ["razor/provideHtmlColorPresentation"] = not_supported,
-    ["razor/provideHtmlDocumentColor"] = not_implemented,
+    ["razor/provideHtmlDocumentColor"] = require("rzls.handlers.providehtmldocumentcolor"),
     ["razor/provideSemanticTokensRange"] = require("rzls.handlers.providesemantictokensrange"),
     ["razor/foldingRange"] = not_implemented,
 

--- a/lua/rzls/handlers/providehtmldocumentcolor.lua
+++ b/lua/rzls/handlers/providehtmldocumentcolor.lua
@@ -1,0 +1,39 @@
+local documentstore = require("rzls.documentstore")
+local razor = require("rzls.razor")
+local Log = require("rzls.log")
+
+local empty_response = {}
+
+---@param _err lsp.ResponseError
+---@param result lsp.DocumentDiagnosticParams
+---@param _ctx lsp.HandlerContext
+---@param _config table
+return function(_err, result, _ctx, _config)
+    assert(not _err, vim.inspect(_err))
+    local virtual_document =
+        documentstore.get_virtual_document(result.textDocument.uri, razor.language_kinds.html, "any")
+    assert(virtual_document, "html document was not found")
+    local virtual_client = virtual_document:get_lsp_client()
+    assert(virtual_client, "Could not find LSP client for virtual document")
+    --@type lsp.DocumentColorParams
+    local document_color_params = vim.tbl_deep_extend("force", result, {
+        textDocument = {
+            uri = vim.uri_from_bufnr(virtual_document.buf),
+        },
+    })
+    local document_color_response = virtual_client.request_sync(
+        vim.lsp.protocol.Methods.textDocument_documentColor,
+        document_color_params,
+        nil,
+        virtual_document.buf
+    )
+    if not document_color_response then
+        return empty_response
+    end
+
+    if document_color_response.err then
+        return nil, document_color_response.err
+    end
+
+    return document_color_response.result
+end

--- a/lua/rzls/init.lua
+++ b/lua/rzls/init.lua
@@ -35,13 +35,6 @@ local defaultConfg = {
     capabilities = vim.lsp.protocol.make_client_capabilities(),
 }
 
----@type lsp.ClientCapabilities
-local extraCapabilities = {
-    textDocument = {
-        colorProvider = {},
-    },
-}
-
 ---@param config rzls.Config
 function M.setup(config)
     Log.rzlsnvim = "Ran Setup"
@@ -119,7 +112,7 @@ function M.setup(config)
                         return req(method, params, handler, tbufnr)
                     end
                 end,
-                capabilities = vim.tbl_deep_extend("force", rzlsconfig.capabilities, extraCapabilities),
+                capabilities = rzlsconfig.capabilities,
                 settings = {
                     html = vim.empty_dict(),
                     razor = vim.empty_dict(),

--- a/lua/rzls/init.lua
+++ b/lua/rzls/init.lua
@@ -37,7 +37,9 @@ local defaultConfg = {
 
 ---@type lsp.ClientCapabilities
 local extraCapabilities = {
-    colorProvider = true,
+    textDocument = {
+        colorProvider = {},
+    },
 }
 
 ---@param config rzls.Config


### PR DESCRIPTION
Implements handler for the `razor/provideHtmlDocumentColor` request sent from the razor language server to client as part of resolving `textDocument/documentColor`.

The lsp request flow is:

client sends `textDocument/documentColor` to razor ls
- razor ls sends `razor/provideHtmlDocumentColor` request to client (handled by rzls.nvim)
  - rzls.nvim handler sends `textDocument/documentColor` request to the html ls attached to the virtual html document for the razor file
  - rzls.nvim responds to razor ls with response from html ls
- razor ls responds to client with response from razor/provideHtmlDocumentColor

Current issues in practice:
- if textDocument/documentColor is sent too quickly, the virtual html document exists but html ls is not attached.
- color updates seem to de-sync at times when editing the text in the buffer (this is likely due to the behavior of the plugin I'm using which implements textDocument/documentColor handling)

Since nvim doesn't provide textDocument/documentColor handling out of the box, that behavior needs to be implemented by plugins e.g. [brenoprata10/nvim-highlight-colors](https://github.com/brenoprata10/nvim-highlight-colors)

```lua
--- brenoprata10/nvim-highlight-colors plugin lazy spec
{
	"brenoprata10/nvim-highlight-colors",
	opts = { render = "virtual" }
}
```

