### PR TITLE
feat: support inlay hints in razor documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ auto-completion, go-to-definition, and more all from within neovim 💻🔧
 | Rename Symbol         | ✅          |
 | Signature Help        | ✅          |
 | Completions           | ✅          |
+| Inlay Hints           | ✅          |
 | Code Actions          | ❌          |
-| Inlay Hints           | ❌          |
 | Folding               | ❌          |
 | CodeLens              | ❌          |
 | Format New Files      | ❌          |
@@ -110,6 +110,13 @@ require('roslyn').setup {
 }
 ```
 
+### Inlay Hints
+
+Inlay hints are provided in razor documents via the roslyn lsp.
+
+To enable, you must enable inlay hinting in nvim config `:h vim.lsp.inlay_hint.enable()`
+and also configure `csharp|inlay_hint_*` options in [roslyn.nvim](https://github.com/seblj/roslyn.nvim)
+
 ## Additional Configuration
 
 ### Telescope
@@ -143,6 +150,7 @@ require('trouble').setup {
       },
 }
 ```
+
 
 ## Known Issues
 

--- a/lua/rzls/documentstore.lua
+++ b/lua/rzls/documentstore.lua
@@ -84,6 +84,21 @@ function M.register_vbufs(source_buf)
     return M.register_vbufs_by_path(currentFile)
 end
 
+---Refreshes parent views of the given virtual document
+---@param result VBufUpdate
+function M.refresh_parent_views(result)
+    local uri = vim.uri_from_fname(result.hostDocumentFilePath)
+    ---@type rzls.VirtualDocument?
+    local rvd = virtual_documents[uri]
+    if not rvd or rvd.kind ~= razor.language_kinds.razor then
+        assert(false, "Not a razor document")
+        return
+    end
+    if vim.lsp.inlay_hint.is_enabled({ bufnr = rvd.buf }) then
+        vim.lsp.inlay_hint.enable(true, { bufnr = rvd.buf })
+    end
+end
+
 ---@async
 ---@param uri string
 ---@param type razor.LanguageKind

--- a/lua/rzls/handlers/init.lua
+++ b/lua/rzls/handlers/init.lua
@@ -33,6 +33,7 @@ return {
     ---@param result VBufUpdate
     ["razor/updateCSharpBuffer"] = function(_err, result)
         documentstore.update_vbuf(result, razor.language_kinds.csharp)
+        documentstore.refresh_parent_views(result)
     end,
     ---@param _err lsp.ResponseError
     ---@param result VBufUpdate

--- a/lua/rzls/handlers/init.lua
+++ b/lua/rzls/handlers/init.lua
@@ -51,7 +51,7 @@ return {
     ["razor/simplifyMethod"] = not_implemented,
     ["razor/formatNewFile"] = not_implemented,
     ["razor/inlayHint"] = require("rzls.handlers.inlayhint"),
-    ["razor/inlayHintResolve"] = not_implemented,
+    ["razor/inlayHintResolve"] = require("rzls.handlers.inlayhintresolve"),
 
     -- VS Windows only at the moment, but could/should be migrated
     ["razor/documentSymbol"] = not_implemented,

--- a/lua/rzls/handlers/init.lua
+++ b/lua/rzls/handlers/init.lua
@@ -50,7 +50,7 @@ return {
     ["razor/htmlOnTypeFormatting"] = not_implemented,
     ["razor/simplifyMethod"] = not_implemented,
     ["razor/formatNewFile"] = not_implemented,
-    ["razor/inlayHint"] = not_implemented,
+    ["razor/inlayHint"] = require("rzls.handlers.inlayhint"),
     ["razor/inlayHintResolve"] = not_implemented,
 
     -- VS Windows only at the moment, but could/should be migrated

--- a/lua/rzls/handlers/inlayhint.lua
+++ b/lua/rzls/handlers/inlayhint.lua
@@ -1,0 +1,53 @@
+local documentstore = require("rzls.documentstore")
+local razor = require("rzls.razor")
+local Log = require("rzls.log")
+
+local empty_response = {}
+
+--- [rzls:textDocument/inlayHint] rzls language client sends textDocument/inlayHint req to rzls
+--- -> [rzlsnvim:razor/inlayHint] rzls sends razor/inlayHint req rzls language client handled by rzls.nvim
+---   -> [roslyn:textDocument/inlayHint] rlzs.nvim sends textDocument/inlayHint req to roslyn language client attached to c# virtual doc
+--- <- [rzlsnvim:razor/inlayHint] rzls.nvim passes roslyn res back from handler and rzls language client responds to rzls
+--- [rzls:textDocument/inlayHint] rzls responds to rzls language client
+
+---@param _err lsp.ResponseError
+---@param result razor.DelegatedInlayHintParams
+---@param _ctx lsp.HandlerContext
+---@param _config table
+return function(_err, result, _ctx, _config)
+    if
+        not result
+        or not result.identifier
+        or not result.identifier.textDocumentIdentifier
+        or not result.identifier.version
+    then
+        Log.rzlsnvim = "razor/inlayHint: Unexpected result shape. "
+        return empty_response
+    end
+
+    if result.projectedKind ~= razor.language_kinds.csharp then
+        --- inlay hints only supported in csharp for now
+        return empty_response
+    end
+
+    local virtual_document = documentstore.get_virtual_document(
+        result.identifier.textDocumentIdentifier.uri,
+        razor.language_kinds.csharp,
+        result.identifier.version
+    )
+    if not virtual_document then
+        return empty_response
+    end
+    local inlay_hint_params = vim.tbl_deep_extend("force", result, {
+        textDocument = {
+            uri = vim.uri_from_bufnr(virtual_document.buf),
+        },
+        range = result.projectedRange,
+    })
+    local inlay_hint_response =
+        virtual_document:lsp_request(vim.lsp.protocol.Methods.textDocument_inlayHint, inlay_hint_params)
+    if not inlay_hint_response then
+        return empty_response
+    end
+    return inlay_hint_response
+end

--- a/lua/rzls/handlers/inlayhintresolve.lua
+++ b/lua/rzls/handlers/inlayhintresolve.lua
@@ -1,0 +1,42 @@
+local documentstore = require("rzls.documentstore")
+local razor = require("rzls.razor")
+local Log = require("rzls.log")
+
+local empty_response = {}
+
+---@param _err lsp.ResponseError
+---@param result razor.DelegatedInlayHintResolveParams
+---@param _ctx lsp.HandlerContext
+---@param _config table
+return function(_err, result, _ctx, _config)
+    if
+        not result
+        or not result.identifier
+        or not result.identifier.textDocumentIdentifier
+        or not result.identifier.version
+    then
+        Log.rzlsnvim = "razor/inlayHintResolve: Unexpected result shape. "
+        return empty_response
+    end
+
+    if result.projectedKind ~= razor.language_kinds.csharp then
+        --- inlay hints only supported in csharp for now
+        return empty_response
+    end
+
+    local virtual_document = documentstore.get_virtual_document(
+        result.identifier.textDocumentIdentifier.uri,
+        razor.language_kinds.csharp,
+        result.identifier.version
+    )
+    if not virtual_document then
+        return empty_response
+    end
+    local inlay_hint_resolve_params = result.inlayHint
+    local inlay_hint_resolve_response =
+        virtual_document:lsp_request(vim.lsp.protocol.Methods.inlayHint_resolve, inlay_hint_resolve_params)
+    if not inlay_hint_resolve_response then
+        return empty_response
+    end
+    return inlay_hint_resolve_response
+end

--- a/lua/rzls/razor.lua
+++ b/lua/rzls/razor.lua
@@ -52,6 +52,11 @@ local M = {}
 ---@class razor.ProvideDynamicFileResponse
 ---@field csharpDocument? lsp.TextDocumentIdentifier
 
+---@class razor.DelegatedInlayHintParams
+---@field identifier { textDocumentIdentifier: lsp.TextDocumentIdentifier, version: integer }
+---@field projectedKind razor.LanguageKind
+---@field projectedRange lsp.Range
+
 ---@enum razor.LanguageKind
 M.language_kinds = {
     csharp = 1,

--- a/lua/rzls/razor.lua
+++ b/lua/rzls/razor.lua
@@ -57,6 +57,11 @@ local M = {}
 ---@field projectedKind razor.LanguageKind
 ---@field projectedRange lsp.Range
 
+---@class razor.DelegatedInlayHintResolveParams
+---@field identifier { textDocumentIdentifier: lsp.TextDocumentIdentifier, version: integer }
+---@field inlayHint lsp.InlayHint
+---@field projectedKind razor.LanguageKind
+
 ---@enum razor.LanguageKind
 M.language_kinds = {
     csharp = 1,


### PR DESCRIPTION
Implements the razor/inlayHint method which is requested to client from rzls server as part of resolving textDocument/inlayHint.

Also implements inlayHint/resolve but support for this isn't native in neovim's lsp support for inlay hints just yet.

In order to enable inlay hinting, you must specifically enable it in your nvim config `:h vim.lsp.inlay_hint.enable()`.

Inlay hints for razor documents are only supported for csharp and are provided by the roslyn ls. See roslyn.nvim for how to configure the roslyn ls to support inlay hints.

razor/inlayHintResolve is not yet implemented.

Also, I'm seeing desyncing due to document version mismatch between client and server as I edit the csharp code in razor document, it resolves after some time but may be good to figure out what's going on before merging.

![image](https://github.com/user-attachments/assets/b6e66c38-eb3c-4e32-a7f6-2238570ef58c)
