### PR TITLE
refactor(rzls): convert sync LSP requests to async

### DIFF
--- a/lua/rzls/virtual_document.lua
+++ b/lua/rzls/virtual_document.lua
@@ -224,6 +224,7 @@ function VirtualDocument:index_of_position(position)
     return -1
 end
 
+---@async
 ---@param position lsp.Position
 ---@return razor.LanguageQueryResponse|nil    # result on success, nil on failure.
 ---@return nil|lsp.ResponseError # nil on success, error message on failure.
@@ -262,6 +263,7 @@ function VirtualDocument:language_query(position)
     return coroutine.yield()
 end
 
+---@async
 ---@param language_kind razor.LanguageKind
 ---@param ranges lsp.Range[]
 ---@return razor.MapToDocumentRangesResponse|nil    # result on success, nil on failure.
@@ -321,6 +323,7 @@ end
 --- issues an LSP request to the virtual document.
 --- Please use by passing a method from `vim.lsp.protocl.Methods`
 --- and type the expected return value as optional.
+---@async
 ---@param method string
 ---@param params table
 ---@param buf number?


### PR DESCRIPTION
- Commented out preloading code in `documentstore.lua` and `init.lua`
- Updated `language_query`, `map_to_document_ranges`, and `lsp_request` functions in `virtual_document.lua` to use async LSP requests with coroutines

Experimental at the moment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved performance and responsiveness by updating certain operations to use asynchronous processing, resulting in a smoother user experience during language server interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

closes #82 