### PR TITLE
feat: code actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ auto-completion, go-to-definition, and more all from within Neovim 💻🔧
 | Signature Help        | ✅      |
 | Completions           | ✅      |
 | Inlay Hints           | ✅      |
-| Code Actions          | ❌      |
+| Code Actions          | ✅      |
 | Folding               | ✅      |
 | CodeLens              | ❌      |
 | Format New Files      | ❌      |

--- a/lua/rzls/handlers/init.lua
+++ b/lua/rzls/handlers/init.lua
@@ -42,8 +42,8 @@ return {
     ["razor/updateHtmlBuffer"] = function(_err, result)
         documentstore.update_vbuf(result, razor.language_kinds.html)
     end,
-    ["razor/provideCodeActions"] = not_implemented,
-    ["razor/resolveCodeActions"] = not_implemented,
+    ["razor/provideCodeActions"] = require("rzls.handlers.providecodeactions"),
+    ["razor/resolveCodeActions"] = require("rzls.handlers.resolvecodeactions"),
     ["razor/provideHtmlColorPresentation"] = not_supported,
     ["razor/provideHtmlDocumentColor"] = require("rzls.handlers.providehtmldocumentcolor"),
     ["razor/provideSemanticTokensRange"] = require("rzls.handlers.providesemantictokensrange"),
@@ -70,6 +70,8 @@ return {
     ["razor/csharpPullDiagnostics"] = require("rzls.handlers.csharppulldiagnostics"),
     ["razor/completion"] = require("rzls.handlers.completion"),
     ["razor/completionItem/resolve"] = require("rzls.handlers.completionitemresolve"),
+
+    -- Standard LSP methods
     [vim.lsp.protocol.Methods.textDocument_colorPresentation] = not_supported,
     [vim.lsp.protocol.Methods.window_logMessage] = function(_, result)
         Log.rzls = result.message

--- a/lua/rzls/handlers/providecodeactions.lua
+++ b/lua/rzls/handlers/providecodeactions.lua
@@ -1,0 +1,43 @@
+local documentstore = require("rzls.documentstore")
+local razor = require("rzls.razor")
+
+---@class rzls.razorDelegatedCodeAction;
+---@field hostDocumentVersion integer
+---@field codeActionParams lsp.CodeActionParams
+---@field languageKind razor.LanguageKind
+
+local empty_response = {}
+
+---@param err lsp.ResponseError
+---@param result rzls.razorDelegatedCodeAction
+---@param _ctx lsp.HandlerContext
+---@param _config table
+---@return lsp.CodeAction | lsp.CodeAction[] | nil
+---@return lsp.ResponseError | nil
+return function(err, result, _ctx, _config)
+    assert(not err, vim.inspect(err))
+
+    local virtual_document = documentstore.get_virtual_document(
+        result.codeActionParams.textDocument.uri,
+        result.languageKind,
+        result.hostDocumentVersion
+    )
+
+    -- VSCode is only handling C# code actions
+    if not virtual_document or result.languageKind ~= razor.language_kinds.csharp then
+        return empty_response
+    end
+
+    local code_actions_params = vim.tbl_extend("force", result.codeActionParams, {
+        textDocument = vim.lsp.util.make_text_document_params(virtual_document.buf),
+    })
+
+    local code_action_response, code_action_err =
+        virtual_document:lsp_request(vim.lsp.protocol.Methods.textDocument_codeAction, code_actions_params)
+
+    if code_action_err then
+        return nil, code_action_err
+    end
+
+    return code_action_response
+end

--- a/lua/rzls/handlers/providecodeactions.lua
+++ b/lua/rzls/handlers/providecodeactions.lua
@@ -8,15 +8,13 @@ local razor = require("rzls.razor")
 
 local empty_response = {}
 
----@param err lsp.ResponseError
+---@param _err lsp.ResponseError
 ---@param result rzls.razorDelegatedCodeAction
 ---@param _ctx lsp.HandlerContext
 ---@param _config table
 ---@return lsp.CodeAction | lsp.CodeAction[] | nil
 ---@return lsp.ResponseError | nil
-return function(err, result, _ctx, _config)
-    assert(not err, vim.inspect(err))
-
+return function(_err, result, _ctx, _config)
     local virtual_document = documentstore.get_virtual_document(
         result.codeActionParams.textDocument.uri,
         result.languageKind,

--- a/lua/rzls/handlers/resolvecodeactions.lua
+++ b/lua/rzls/handlers/resolvecodeactions.lua
@@ -1,0 +1,37 @@
+local documentstore = require("rzls.documentstore")
+local razor = require("rzls.razor")
+
+---@class rzls.razorResolveCodeActionParams;
+---@field hostDocumentVersion integer
+---@field identifier lsp.TextDocumentIdentifier
+---@field languageKind razor.LanguageKind
+---@field codeAction lsp.CodeAction
+
+local empty_response = {}
+
+---@param err lsp.ResponseError
+---@param result rzls.razorResolveCodeActionParams
+---@param _ctx lsp.HandlerContext
+---@param _config table
+---@return lsp.CodeAction | lsp.CodeAction[] | nil
+---@return lsp.ResponseError | nil
+return function(err, result, _ctx, _config)
+    assert(not err, vim.inspect(err))
+
+    local virtual_document =
+        documentstore.get_virtual_document(result.identifier.uri, result.languageKind, result.hostDocumentVersion)
+
+    -- VSCode is only handling C# code actions
+    if not virtual_document or result.languageKind ~= razor.language_kinds.csharp then
+        return empty_response
+    end
+
+    local code_action_resolve_response, code_action_resolve_err =
+        virtual_document:lsp_request(vim.lsp.protocol.Methods.codeAction_resolve, result.codeAction)
+
+    if code_action_resolve_err then
+        return nil, code_action_resolve_err
+    end
+
+    return code_action_resolve_response
+end

--- a/lua/rzls/handlers/resolvecodeactions.lua
+++ b/lua/rzls/handlers/resolvecodeactions.lua
@@ -9,15 +9,13 @@ local razor = require("rzls.razor")
 
 local empty_response = {}
 
----@param err lsp.ResponseError
+---@param _err lsp.ResponseError
 ---@param result rzls.razorResolveCodeActionParams
 ---@param _ctx lsp.HandlerContext
 ---@param _config table
 ---@return lsp.CodeAction | lsp.CodeAction[] | nil
 ---@return lsp.ResponseError | nil
-return function(err, result, _ctx, _config)
-    assert(not err, vim.inspect(err))
-
+return function(_err, result, _ctx, _config)
     local virtual_document =
         documentstore.get_virtual_document(result.identifier.uri, result.languageKind, result.hostDocumentVersion)
 

--- a/lua/rzls/server/lsp.lua
+++ b/lua/rzls/server/lsp.lua
@@ -41,6 +41,12 @@ local requests = {
                     full = true,
                     legend = rzls_client.server_capabilities.semanticTokensProvider.legend,
                 },
+                -- Same capabilities that rzls provides
+                codeActionProvider = {
+                    codeActionKinds = { "refactor.extract", "quickfix", "refactor" },
+                    resolveProvider = true,
+                    workDoneProgress = false,
+                },
             },
         }
     end,
@@ -52,6 +58,8 @@ local requests = {
     [vim.lsp.protocol.Methods.textDocument_signatureHelp] = require("rzls.server.methods.signaturehelp"),
     [vim.lsp.protocol.Methods.textDocument_documentHighlight] = require("rzls.server.methods.documenthighlight"),
     [vim.lsp.protocol.Methods.textDocument_semanticTokens_full] = require("rzls.server.methods.semantictokens_full"),
+    [vim.lsp.protocol.Methods.textDocument_codeAction] = require("rzls.server.methods.codeaction"),
+    [vim.lsp.protocol.Methods.codeAction_resolve] = require("rzls.server.methods.codeactionresolve"),
 }
 
 local noops = {

--- a/lua/rzls/server/lsp.lua
+++ b/lua/rzls/server/lsp.lua
@@ -19,8 +19,10 @@ local requests = {
         end
 
         ---disable in rzls the things that aftershave will directly
+        ---@type lsp.ServerCapabilities
         local rzls_disabled_capabilities = {
             renameProvider = false,
+            codeActionProvider = false,
         }
         rzls_client.server_capabilities =
             vim.tbl_deep_extend("force", rzls_client.server_capabilities, rzls_disabled_capabilities)

--- a/lua/rzls/server/lsp.lua
+++ b/lua/rzls/server/lsp.lua
@@ -24,6 +24,9 @@ local requests = {
             renameProvider = false,
             codeActionProvider = false,
         }
+
+        local original_rzls_server_capabilities = rzls_client.server_capabilities
+
         rzls_client.server_capabilities =
             vim.tbl_deep_extend("force", rzls_client.server_capabilities, rzls_disabled_capabilities)
 
@@ -43,12 +46,7 @@ local requests = {
                     full = true,
                     legend = rzls_client.server_capabilities.semanticTokensProvider.legend,
                 },
-                -- Same capabilities that rzls provides
-                codeActionProvider = {
-                    codeActionKinds = { "refactor.extract", "quickfix", "refactor" },
-                    resolveProvider = true,
-                    workDoneProgress = false,
-                },
+                codeActionProvider = original_rzls_server_capabilities.codeActionProvider,
             },
         }
     end,

--- a/lua/rzls/server/methods/codeaction.lua
+++ b/lua/rzls/server/methods/codeaction.lua
@@ -1,0 +1,23 @@
+local documentstore = require("rzls.documentstore")
+local razor = require("rzls.razor")
+
+---@param params lsp.CodeActionParams
+---@return (lsp.Command | lsp.CodeAction)[] | nil
+return function(params)
+    local rvd = documentstore.get_virtual_document(params.textDocument.uri, razor.language_kinds.razor)
+
+    if not rvd then
+        return
+    end
+
+    local code_action, code_action_err = rvd:lsp_request(vim.lsp.protocol.Methods.textDocument_codeAction, params)
+
+    if code_action_err then
+        vim.notify("Error requesting code action: " .. code_action_err.message, vim.log.levels.ERROR, {
+            title = "rzls",
+        })
+        return
+    end
+
+    return code_action
+end

--- a/lua/rzls/server/methods/codeactionresolve.lua
+++ b/lua/rzls/server/methods/codeactionresolve.lua
@@ -1,19 +1,27 @@
 local documentstore = require("rzls.documentstore")
 local razor = require("rzls.razor")
 
----@param params lsp.CodeAction
+-- HACK: neovim does not deserialize `null`s and rzls expects an explicit `null` value
+-- in the `data.delegatedDocumentUri` field of a code action.
+-- This issue is being tracker here: https://github.com/neovim/neovim/issues/31368
+-- We can remove code actions from aftershave when this issue is resolved.
+local code_action_required_fields = {
+    data = {
+        delegatedDocumentUri = vim.NIL,
+    },
+}
+
+---@param code_action lsp.CodeAction
 ---@return lsp.CodeAction | nil
-return function(params)
-    local rvd = documentstore.get_virtual_document(params.data.TextDocument.uri, razor.language_kinds.razor)
+return function(code_action)
+    ---@diagnostic disable-next-line: undefined-field
+    local rvd = documentstore.get_virtual_document(code_action.data.TextDocument.uri, razor.language_kinds.razor)
 
     if not rvd then
         return
     end
 
-    -- HACK: neovim does not deserialize `null`s and rzls expects an explicit `null` value
-    -- in the `params.data.delegatedDocumentUri` field.
-    params.data.delegatedDocumentUri = vim.NIL
-
+    local params = vim.tbl_deep_extend("keep", code_action, code_action_required_fields)
     local resolve, resolve_err = rvd:lsp_request(vim.lsp.protocol.Methods.codeAction_resolve, params)
 
     if resolve_err then

--- a/lua/rzls/server/methods/codeactionresolve.lua
+++ b/lua/rzls/server/methods/codeactionresolve.lua
@@ -1,0 +1,27 @@
+local documentstore = require("rzls.documentstore")
+local razor = require("rzls.razor")
+
+---@param params lsp.CodeAction
+---@return lsp.CodeAction | nil
+return function(params)
+    local rvd = documentstore.get_virtual_document(params.data.TextDocument.uri, razor.language_kinds.razor)
+
+    if not rvd then
+        return
+    end
+
+    -- HACK: neovim does not deserialize `null`s and rzls expects an explicit `null` value
+    -- in the `params.data.delegatedDocumentUri` field.
+    params.data.delegatedDocumentUri = vim.NIL
+
+    local resolve, resolve_err = rvd:lsp_request(vim.lsp.protocol.Methods.codeAction_resolve, params)
+
+    if resolve_err then
+        vim.notify("Error resolving code action: " .. resolve_err.message, vim.log.levels.ERROR, {
+            title = "rzls",
+        })
+        return
+    end
+
+    return resolve
+end


### PR DESCRIPTION
Because of the hack to add 'vim.NIL' to 'data.delegatedDocumentUri' in 'codeAction/resolve`, I moved the code action handling to aftershave.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for providing and resolving code actions in Razor files, enabling users to access relevant code actions within Razor documents.
- **Bug Fixes**
  - Improved handling of code action capabilities to ensure compatibility and correct behavior in the editor.
- **Documentation**
  - Updated README to reflect support for code actions in Razor files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->