### PR TITLE
fix(documentstore): support new roslyn sync and lazy loading

### DIFF
--- a/lua/rzls/documentstore.lua
+++ b/lua/rzls/documentstore.lua
@@ -72,9 +72,24 @@ function M.register_vbufs_by_path(current_file, ensure_open)
     end
 
     local html_uri = current_file .. razor.virtual_suffixes["html"]
-    if virtual_documents[current_file][razor.language_kinds.html] == nil then
+    if not virtual_documents[current_file][razor.language_kinds.html] then
+        local opened = document_is_open(html_uri)
+        if not opened and not ensure_open then
+            virtual_documents[current_file][razor.language_kinds.html] =
+                VirtualDocument:new(nil, razor.language_kinds.html, html_uri)
+        else
+            local buf = vim.uri_to_bufnr(html_uri)
+            virtual_documents[current_file][razor.language_kinds.html] =
+                VirtualDocument:new(buf, razor.language_kinds.html)
+        end
+    end
+
+    if ensure_open then
         local buf = vim.uri_to_bufnr(html_uri)
-        virtual_documents[current_file][razor.language_kinds.html] = VirtualDocument:new(buf, razor.language_kinds.html)
+        ---@type rzls.VirtualDocument
+        local hvd = virtual_documents[current_file][razor.language_kinds.html]
+        local success = hvd:update_bufnr(buf)
+        assert(success, "Failed to update bufnr for " .. html_uri)
     end
 end
 

--- a/lua/rzls/documentstore.lua
+++ b/lua/rzls/documentstore.lua
@@ -97,9 +97,9 @@ end
 ---@param language_kind razor.LanguageKind
 function M.update_vbuf(result, language_kind)
     M.register_vbufs_by_path(result.hostDocumentFilePath, false)
-    local uri = vim.uri_from_fname(result.hostDocumentFilePath)
+    local razor_uri = vim.uri_from_fname(result.hostDocumentFilePath)
     ---@type rzls.VirtualDocument
-    local virtual_document = virtual_documents[uri][language_kind]
+    local virtual_document = virtual_documents[razor_uri][language_kind]
 
     virtual_document.checksum = result.checksum
     virtual_document.checksum_algorithm = result.checksumAlgorithm or 1
@@ -118,7 +118,7 @@ function M.update_vbuf(result, language_kind)
         ---@type razor.DynamicFileUpdatedParams
         local params = {
             razorDocument = {
-                uri = virtual_documents[uri].path,
+                uri = virtual_documents[razor_uri].uri,
             },
         }
 
@@ -188,7 +188,7 @@ function M.get_virtual_document(uri, type, version)
     if virtual_document.host_document_version ~= version then
         Log.rzlsnvim = string.format(
             'Mismatch between virtual document version. Uri: "%s". Server: %d. Client: %d',
-            virtual_document.path,
+            virtual_document.uri,
             version,
             virtual_document.host_document_version
         )

--- a/lua/rzls/documentstore.lua
+++ b/lua/rzls/documentstore.lua
@@ -66,6 +66,7 @@ function M.register_vbufs_by_path(current_file, ensure_open)
                 VirtualDocument:new(nil, razor.language_kinds.csharp, name)
         else
             local buf = get_or_create_vbuffer_for_uri(current_file, "csharp")
+            vim.api.nvim_set_option_value("filetype", "cs", { buf = buf })
             vim.defer_fn(function()
                 -- Defer setting buftype to nowrite to let LSP attach
                 vim.api.nvim_set_option_value("buftype", "nowrite", { buf = buf })
@@ -79,6 +80,7 @@ function M.register_vbufs_by_path(current_file, ensure_open)
     if ensure_open then
         local name = current_file .. razor.virtual_suffixes["csharp"]
         local buf = vim.uri_to_bufnr(name)
+        vim.api.nvim_set_option_value("filetype", "cs", { buf = buf })
         ---@type rzls.VirtualDocument
         local cvd = virtual_documents[current_file][razor.language_kinds.csharp]
         local success = cvd:update_bufnr(buf)

--- a/lua/rzls/handlers/completion.lua
+++ b/lua/rzls/handlers/completion.lua
@@ -16,7 +16,7 @@ local function provide_lsp_completions(virtual_document, projected_position, tri
         },
         position = projected_position,
         textDocument = {
-            uri = vim.uri_from_bufnr(virtual_document.buf),
+            uri = virtual_document.path,
         },
     }
     local response = virtual_document:lsp_request(vim.lsp.protocol.Methods.textDocument_completion, params)

--- a/lua/rzls/handlers/completion.lua
+++ b/lua/rzls/handlers/completion.lua
@@ -16,7 +16,7 @@ local function provide_lsp_completions(virtual_document, projected_position, tri
         },
         position = projected_position,
         textDocument = {
-            uri = virtual_document.path,
+            uri = virtual_document.uri,
         },
     }
     local response = virtual_document:lsp_request(vim.lsp.protocol.Methods.textDocument_completion, params)

--- a/lua/rzls/handlers/csharppulldiagnostics.lua
+++ b/lua/rzls/handlers/csharppulldiagnostics.lua
@@ -17,7 +17,7 @@ return function(_err, result, _ctx, _config)
     ---@type lsp.DocumentDiagnosticParams
     local diagnostic_params = vim.tbl_deep_extend("force", result, {
         textDocument = {
-            uri = virtual_document.path,
+            uri = virtual_document.uri,
         },
     })
 

--- a/lua/rzls/handlers/csharppulldiagnostics.lua
+++ b/lua/rzls/handlers/csharppulldiagnostics.lua
@@ -17,7 +17,7 @@ return function(_err, result, _ctx, _config)
     ---@type lsp.DocumentDiagnosticParams
     local diagnostic_params = vim.tbl_deep_extend("force", result, {
         textDocument = {
-            uri = vim.uri_from_bufnr(virtual_document.buf),
+            uri = virtual_document.path,
         },
     })
 

--- a/lua/rzls/handlers/inlayhint.lua
+++ b/lua/rzls/handlers/inlayhint.lua
@@ -40,7 +40,7 @@ return function(_err, result, _ctx, _config)
     end
     local inlay_hint_params = vim.tbl_deep_extend("force", result, {
         textDocument = {
-            uri = vim.uri_from_bufnr(virtual_document.buf),
+            uri = virtual_document.path,
         },
         range = result.projectedRange,
     })

--- a/lua/rzls/handlers/inlayhint.lua
+++ b/lua/rzls/handlers/inlayhint.lua
@@ -40,7 +40,7 @@ return function(_err, result, _ctx, _config)
     end
     local inlay_hint_params = vim.tbl_deep_extend("force", result, {
         textDocument = {
-            uri = virtual_document.path,
+            uri = virtual_document.uri,
         },
         range = result.projectedRange,
     })

--- a/lua/rzls/handlers/providehtmldocumentcolor.lua
+++ b/lua/rzls/handlers/providehtmldocumentcolor.lua
@@ -24,7 +24,7 @@ return function(_err, result, _ctx, _config)
     ---@type lsp.DocumentColorParams
     local document_color_params = {
         textDocument = {
-            uri = virtual_document.path,
+            uri = virtual_document.uri,
         },
     }
 

--- a/lua/rzls/handlers/providehtmldocumentcolor.lua
+++ b/lua/rzls/handlers/providehtmldocumentcolor.lua
@@ -24,7 +24,7 @@ return function(_err, result, _ctx, _config)
     ---@type lsp.DocumentColorParams
     local document_color_params = {
         textDocument = {
-            uri = vim.uri_from_bufnr(virtual_document.buf),
+            uri = virtual_document.path,
         },
     }
 

--- a/lua/rzls/handlers/providesemantictokensrange.lua
+++ b/lua/rzls/handlers/providesemantictokensrange.lua
@@ -23,7 +23,7 @@ return function(_err, result, _ctx, _config)
     ---@type lsp.SemanticTokens?
     local tokens, err = vd:lsp_request(vim.lsp.protocol.Methods.textDocument_semanticTokens_range, {
         textDocument = {
-            uri = vim.uri_from_bufnr(vd.buf),
+            uri = vd.path,
         },
         range = result.ranges[1],
         correlationId = result.correlationId,

--- a/lua/rzls/handlers/providesemantictokensrange.lua
+++ b/lua/rzls/handlers/providesemantictokensrange.lua
@@ -23,7 +23,7 @@ return function(_err, result, _ctx, _config)
     ---@type lsp.SemanticTokens?
     local tokens, err = vd:lsp_request(vim.lsp.protocol.Methods.textDocument_semanticTokens_range, {
         textDocument = {
-            uri = vd.path,
+            uri = vd.uri,
         },
         range = result.ranges[1],
         correlationId = result.correlationId,

--- a/lua/rzls/handlers/types.lua
+++ b/lua/rzls/handlers/types.lua
@@ -1,4 +1,7 @@
 ---@class VBufUpdate
+---@field checksum string
+---@field checksumAlgorithm number
+---@field encodingCodePage? number
 ---@field previousWasEmpty boolean
 ---@field hostDocumentFilePath string
 ---@field hostDocumentVersion number

--- a/lua/rzls/health.lua
+++ b/lua/rzls/health.lua
@@ -21,7 +21,7 @@ M.check = function()
 
         for _, lang in pairs({ "csharp", "html" }) do
             local doc = docs[razor.language_kinds[lang]]
-            if doc and doc.buf and doc.path then
+            if doc and doc.buf and doc.uri then
                 vim.health.ok(
                     "  "
                         .. lang
@@ -30,7 +30,7 @@ M.check = function()
                         .. "] [v:"
                         .. doc.host_document_version
                         .. "]"
-                        .. doc.path
+                        .. doc.uri
                 )
             else
                 vim.health.ok("  " .. lang .. " virtual document not open")

--- a/lua/rzls/health.lua
+++ b/lua/rzls/health.lua
@@ -16,7 +16,7 @@ M.check = function()
                 "razor virtual document open: [buf:" .. docs.buf .. "] [v:" .. docs.host_document_version .. "]"
             )
         else
-            vim.health.info("razor virtual document not open")
+            vim.health.ok("razor virtual document not open")
         end
 
         for _, lang in pairs({ "csharp", "html" }) do
@@ -33,7 +33,13 @@ M.check = function()
                         .. doc.path
                 )
             else
-                vim.health.error("  " .. lang .. " virtual document not found")
+                if lang == "html" then
+                    vim.health.error("  " .. lang .. " virtual document not found")
+                elseif lang == "csharp" then
+                    vim.health.ok("  " .. lang .. " virtual document not open")
+                else
+                    vim.error("HOW DID I GET HERE? " .. lang)
+                end
             end
         end
     end

--- a/lua/rzls/health.lua
+++ b/lua/rzls/health.lua
@@ -44,7 +44,20 @@ M.check = function()
         end
     end
 
-    vim.health.start("roslyn pipe")
+    vim.health.start("lsp info")
+
+    local lsps = {
+        roslyn = vim.lsp.get_clients({ name = razor.lsp_names[razor.language_kinds.csharp] })[1],
+        rzls = vim.lsp.get_clients({ name = razor.lsp_names[razor.language_kinds.razor] })[1],
+        html = vim.lsp.get_clients({ name = razor.lsp_names[razor.language_kinds.html] })[1],
+    }
+    for name, client in pairs(lsps) do
+        if not client then
+            vim.health.error("lsp client " .. name .. " not found")
+        else
+            vim.health.ok("lsp client " .. name .. " found")
+        end
+    end
 
     local roslyn_pipe_id = require("rzls.documentstore").get_roslyn_pipe
 

--- a/lua/rzls/health.lua
+++ b/lua/rzls/health.lua
@@ -6,14 +6,17 @@ M.check = function()
     vim.health.start("rzls.nvim report")
     -- make sure setup function parameters are ok
 
+    vim.health.start("document store")
     ---@type rzls.VirtualDocument<string, table<razor.LanguageKind, rzls.VirtualDocument>>
     local document_store = require("rzls.documentstore").get_docstore
     for razor_filename, docs in pairs(document_store) do
         vim.health.info("razor file: " .. razor_filename)
         if docs.buf then
-            vim.health.ok("razor virtual document found: " .. docs.buf .. " v: " .. docs.host_document_version)
+            vim.health.ok(
+                "razor virtual document open: [buf:" .. docs.buf .. "] [v:" .. docs.host_document_version .. "]"
+            )
         else
-            vim.health.error("razor virtual document not found")
+            vim.health.info("razor virtual document not open")
         end
 
         for _, lang in pairs({ "csharp", "html" }) do
@@ -34,6 +37,8 @@ M.check = function()
             end
         end
     end
+
+    vim.health.start("roslyn pipe")
 
     local roslyn_pipe_id = require("rzls.documentstore").get_roslyn_pipe
 

--- a/lua/rzls/health.lua
+++ b/lua/rzls/health.lua
@@ -33,13 +33,7 @@ M.check = function()
                         .. doc.path
                 )
             else
-                if lang == "html" then
-                    vim.health.error("  " .. lang .. " virtual document not found")
-                elseif lang == "csharp" then
-                    vim.health.ok("  " .. lang .. " virtual document not open")
-                else
-                    vim.error("HOW DID I GET HERE? " .. lang)
-                end
+                vim.health.ok("  " .. lang .. " virtual document not open")
             end
         end
     end

--- a/lua/rzls/init.lua
+++ b/lua/rzls/init.lua
@@ -81,7 +81,7 @@ function M.setup(config)
                 root_dir = root_dir,
                 on_attach = function(client, bufnr)
                     razor.apply_highlights()
-                    documentstore.register_vbufs(bufnr)
+                    documentstore.register_vbufs_by_path(vim.uri_to_fname(vim.uri_from_bufnr(bufnr)), true)
                     rzlsconfig.on_attach(client, bufnr)
                 end,
                 capabilities = rzlsconfig.capabilities,

--- a/lua/rzls/init.lua
+++ b/lua/rzls/init.lua
@@ -64,7 +64,6 @@ function M.setup(config)
                     "true",
                 },
                 on_init = function(client, _initialize_result)
-                    documentstore.load_existing_files(client.root_dir)
                     ---@module "roslyn"
                     local roslyn_pipes = require("roslyn.server").get_pipes()
                     if roslyn_pipes[root_dir] then
@@ -78,7 +77,6 @@ function M.setup(config)
                             group = au,
                         })
                     end
-                    M.watch_new_files(root_dir)
                 end,
                 root_dir = root_dir,
                 on_attach = function(client, bufnr)
@@ -123,26 +121,6 @@ function M.setup(config)
         group = au,
         callback = razor.apply_highlights,
     })
-end
-
-function M.watch_new_files(path)
-    local w = vim.uv.new_fs_event()
-    assert(w)
-
-    local fullpath = vim.fn.fnamemodify(path, ":p")
-
-    w:start(fullpath, {
-        recursive = true,
-    }, function(err, filename, _events)
-        assert(not err, err)
-        Log.rzlsnvim = "Filesystem changed - " .. filename
-        if vim.fn.fnamemodify(filename, ":e") == "razor" then
-            Log.rzlsnvim = "Filesystem changed  " .. filename .. " updating documentstore"
-            vim.schedule(function()
-                documentstore.register_vbufs_by_path(filename)
-            end)
-        end
-    end)
 end
 
 return M

--- a/lua/rzls/razor.lua
+++ b/lua/rzls/razor.lua
@@ -53,6 +53,9 @@ local M = {}
 ---@class razor.ProvideDynamicFileResponse
 ---@field csharpDocument? lsp.TextDocumentIdentifier
 
+---@class razor.DynamicFileUpdatedParams
+---@field razorDocument lsp.TextDocumentIdentifier
+
 ---@class razor.DelegatedInlayHintParams
 ---@field identifier { textDocumentIdentifier: lsp.TextDocumentIdentifier, version: integer }
 ---@field projectedKind razor.LanguageKind
@@ -87,6 +90,7 @@ M.notification = {
     razor_namedPipeConnect = "razor/namedPipeConnect",
     razor_initialize = "razor/initialize",
     razor_dynamicFileInfoChanged = "razor/dynamicFileInfoChanged",
+    razor_provideDynamicFileInfo = "razor/provideDynamicFileInfo",
 }
 
 ---@type table<string, vim.api.keyset.highlight>

--- a/lua/rzls/razor.lua
+++ b/lua/rzls/razor.lua
@@ -52,6 +52,13 @@ local M = {}
 
 ---@class razor.ProvideDynamicFileResponse
 ---@field csharpDocument? lsp.TextDocumentIdentifier
+---@field updates? razor.DynamicFileUpdate[]
+---@field checksum string
+---@field checksumAlgorithm number
+---@field enodingCodePage number
+
+---@class razor.DynamicFileUpdate
+---@field edits Change[]
 
 ---@class razor.DynamicFileUpdatedParams
 ---@field razorDocument lsp.TextDocumentIdentifier

--- a/lua/rzls/razor.lua
+++ b/lua/rzls/razor.lua
@@ -48,6 +48,7 @@ local M = {}
 
 ---@class razor.ProvideDynamicFileParams
 ---@field razorDocument lsp.TextDocumentIdentifier
+---@field fullText boolean
 
 ---@class razor.ProvideDynamicFileResponse
 ---@field csharpDocument? lsp.TextDocumentIdentifier
@@ -80,6 +81,12 @@ M.lsp_names = {
     [M.language_kinds.html] = "html",
     [M.language_kinds.csharp] = "roslyn",
     [M.language_kinds.razor] = "rzls",
+}
+
+M.notification = {
+    razor_namedPipeConnect = "razor/namedPipeConnect",
+    razor_initialize = "razor/initialize",
+    razor_dynamicFileInfoChanged = "razor/dynamicFileInfoChanged",
 }
 
 ---@type table<string, vim.api.keyset.highlight>

--- a/lua/rzls/roslyn_handlers.lua
+++ b/lua/rzls/roslyn_handlers.lua
@@ -14,8 +14,6 @@ local function roslyn_razor_provideDynamicFileHandler(_err, result, _ctx, _confi
     local root_dir = (razor_client and razor_client.root_dir) or (roslyn_client and roslyn_client.root_dir)
     assert(root_dir, "Could not find root directory")
 
-    documentstore.load_existing_files(root_dir)
-
     if result.razorDocument == nil then
         return nil, vim.lsp.rpc.rpc_response_error(-32602, "Missing razorDocument")
     end
@@ -23,16 +21,33 @@ local function roslyn_razor_provideDynamicFileHandler(_err, result, _ctx, _confi
     if not vd then
         return nil, vim.lsp.rpc.rpc_response_error(-32600, "Could not find requested document")
     end
-    local bufnr = vd.buf
 
-    if bufnr == nil then
-        return nil, vim.lsp.rpc.rpc_response_error(-32600, "Could not find requested document")
+    ---@type Change[]
+    local full_change
+    if result.FullText then
+        --NOTE: This shouldnt happen at the moment
+        --But we will support it when we dont open all the documents on a vbuf update
+        full_change = {
+            {
+                newText = vd.content,
+                span = {
+                    start = 0,
+                    length = 0,
+                },
+            },
+        }
+        vim.print("requested full")
+        vim.print(vim.inspect(result))
+        assert(false, "Not implemented")
     end
-
     return {
         csharpDocument = {
-            uri = vim.uri_from_bufnr(bufnr),
+            uri = vim.uri_from_bufnr(vd.buf),
         },
+        checksum = vd.checksum,
+        checksumAlgorithm = vd.checksum_algorithm,
+        enodingCodePage = vd.encoding_code_page,
+        edits = result.FullText and full_change or vd.edits,
     }
 end
 

--- a/lua/rzls/roslyn_handlers.lua
+++ b/lua/rzls/roslyn_handlers.lua
@@ -20,7 +20,7 @@ local function roslyn_razor_provideDynamicFileHandler(_err, result, _ctx, _confi
         ---@type razor.ProvideDynamicFileResponse
         local resp = {
             csharpDocument = {
-                uri = vd.path,
+                uri = vd.uri,
             },
             checksum = vd.checksum,
             checksumAlgorithm = vd.checksum_algorithm,
@@ -51,7 +51,7 @@ local function roslyn_razor_provideDynamicFileHandler(_err, result, _ctx, _confi
     ---@type razor.ProvideDynamicFileResponse
     local resp = {
         csharpDocument = {
-            uri = vd.path,
+            uri = vd.uri,
         },
         checksum = vd.checksum,
         checksumAlgorithm = vd.checksum_algorithm,

--- a/lua/rzls/server/methods/definition.lua
+++ b/lua/rzls/server/methods/definition.lua
@@ -19,7 +19,7 @@ return function(params)
     end
 
     local virtual_document = documentstore.get_virtual_document(
-        rvd.path,
+        rvd.uri,
         language_query_response.kind,
         language_query_response.hostDocumentVersion
     )
@@ -30,7 +30,7 @@ return function(params)
     ---@type lsp.Definition?
     local definition_result = virtual_document:lsp_request(vim.lsp.protocol.Methods.textDocument_definition, {
         textDocument = {
-            uri = virtual_document.path,
+            uri = virtual_document.uri,
         },
         position = language_query_response.position,
     })

--- a/lua/rzls/server/methods/hover.lua
+++ b/lua/rzls/server/methods/hover.lua
@@ -19,7 +19,7 @@ return function(params)
     end
 
     local virtual_document = documentstore.get_virtual_document(
-        rvd.path,
+        rvd.uri,
         language_query_response.kind,
         language_query_response.hostDocumentVersion
     )
@@ -30,7 +30,7 @@ return function(params)
     ---@type lsp.Hover?
     local hover_result = virtual_document:lsp_request(vim.lsp.protocol.Methods.textDocument_hover, {
         textDocument = {
-            uri = virtual_document.path,
+            uri = virtual_document.uri,
         },
         position = language_query_response.position,
     })

--- a/lua/rzls/server/methods/references.lua
+++ b/lua/rzls/server/methods/references.lua
@@ -19,7 +19,7 @@ return function(params)
     end
 
     local virtual_document = documentstore.get_virtual_document(
-        rvd.path,
+        rvd.uri,
         language_query_response.kind,
         language_query_response.hostDocumentVersion
     )
@@ -30,7 +30,7 @@ return function(params)
     ---@type lsp.Location[]?
     local references_result = virtual_document:lsp_request(vim.lsp.protocol.Methods.textDocument_references, {
         textDocument = {
-            uri = virtual_document.path,
+            uri = virtual_document.uri,
         },
         position = language_query_response.position,
         context = {

--- a/lua/rzls/server/methods/rename.lua
+++ b/lua/rzls/server/methods/rename.lua
@@ -45,7 +45,7 @@ return function(params)
     ---@type lsp.WorkspaceEdit?
     local edits, editerr = csvd:lsp_request(vim.lsp.protocol.Methods.textDocument_rename, {
         textDocument = {
-            uri = csvd.path,
+            uri = csvd.uri,
         },
         position = language_query_response.position,
         newName = params.newName,

--- a/lua/rzls/server/methods/signaturehelp.lua
+++ b/lua/rzls/server/methods/signaturehelp.lua
@@ -19,7 +19,7 @@ return function(params)
     end
 
     local vd = documentstore.get_virtual_document(
-        rvd.path,
+        rvd.uri,
         language_query_response.kind,
         language_query_response.hostDocumentVersion
     )
@@ -30,7 +30,7 @@ return function(params)
     ---@type lsp.SignatureHelp?
     local sig_help = vd:lsp_request(vim.lsp.protocol.Methods.textDocument_signatureHelp, {
         textDocument = {
-            uri = vd.path,
+            uri = vd.uri,
         },
         position = language_query_response.position,
         context = params.context,

--- a/tests/rzls/documentstore_spec.lua
+++ b/tests/rzls/documentstore_spec.lua
@@ -8,21 +8,20 @@ describe("documentstore", function()
         local path = "tests/rzls/fixtures/test2.razor"
         local path_prefix = vim.loop.cwd() .. "/"
         local full_path = "file://" .. path_prefix .. path
-        vim.cmd.edit({ args = { path } })
-        local init_buf = vim.api.nvim_list_bufs()
-        documentstore.register_vbufs(init_buf[1])
+        documentstore.register_vbufs_by_path(path_prefix .. path, true)
         for _, lang in pairs({ 1, 2 }) do
-            local doc = documentstore.get_virtual_document(full_path, lang, 0)
+            local doc = documentstore.get_virtual_document(full_path, lang, "any")
             assert(doc, "Could not find virtual document")
             eq(doc.kind, lang)
         end
         local bufs = vim.api.nvim_list_bufs()
         local names = {}
-        eq(#bufs, 3)
+        eq(#bufs, 4)
         for _, buf in ipairs(bufs) do
             names[buf] = vim.api.nvim_buf_get_name(buf)
         end
         eq({
+            "",
             path_prefix .. "tests/rzls/fixtures/test2.razor",
             path_prefix .. "tests/rzls/fixtures/test2.razor__virtual.cs",
             path_prefix .. "tests/rzls/fixtures/test2.razor__virtual.html",

--- a/tests/rzls/virtual_document_spec.lua
+++ b/tests/rzls/virtual_document_spec.lua
@@ -6,7 +6,7 @@ local eq = assert.are.same
 describe("virtual document", function()
     local vd
     local path = "tests/rzls/fixtures/vdtest.razor__virtual.html"
-    local full_path = "file://" .. vim.loop.cwd() .. "/" .. path
+    local uri = "file://" .. vim.loop.cwd() .. "/" .. path
     vim.cmd.edit({ args = { path } })
     local ls = vim.fn.getbufinfo({ buflisted = 1 })
     local bufnr = ls[1].bufnr
@@ -18,7 +18,7 @@ describe("virtual document", function()
             host_document_version = 0,
             content = "",
             kind = razor.language_kinds.html,
-            path = full_path,
+            uri = uri,
             updates = {},
             change_event = {
                 listeners = {},
@@ -31,7 +31,7 @@ describe("virtual document", function()
             {
                 previousWasEmpty = true,
                 hostDocumentVersion = 1,
-                hostDocumentFilePath = full_path,
+                hostDocumentFilePath = uri,
                 changes = {
                     {
                         newText = "Hello\n",
@@ -49,7 +49,7 @@ describe("virtual document", function()
             host_document_version = 1,
             content = "Hello\n",
             kind = razor.language_kinds.html,
-            path = full_path,
+            uri = uri,
             updates = {},
             change_event = {
                 listeners = {},
@@ -59,7 +59,7 @@ describe("virtual document", function()
             {
                 previousWasEmpty = false,
                 hostDocumentVersion = 2,
-                hostDocumentFilePath = full_path,
+                hostDocumentFilePath = uri,
                 changes = {
                     {
                         newText = " World\n",
@@ -77,7 +77,7 @@ describe("virtual document", function()
             host_document_version = 2,
             content = "Hello World\n",
             kind = razor.language_kinds.html,
-            path = full_path,
+            uri = uri,
             updates = {},
             change_event = {
                 listeners = {},
@@ -88,7 +88,7 @@ describe("virtual document", function()
             {
                 previousWasEmpty = false,
                 hostDocumentVersion = 3,
-                hostDocumentFilePath = full_path,
+                hostDocumentFilePath = uri,
                 changes = {
                     {
                         newText = "stuff\n",
@@ -106,7 +106,7 @@ describe("virtual document", function()
             host_document_version = 3,
             content = "Hello stuff\n",
             kind = razor.language_kinds.html,
-            path = full_path,
+            uri = uri,
             updates = {},
             change_event = {
                 listeners = {},
@@ -117,7 +117,7 @@ describe("virtual document", function()
             {
                 previousWasEmpty = false,
                 hostDocumentVersion = 4,
-                hostDocumentFilePath = full_path,
+                hostDocumentFilePath = uri,
                 changes = {
                     {
                         newText = "in the middle ",
@@ -135,7 +135,7 @@ describe("virtual document", function()
             host_document_version = 4,
             content = "Hello in the middle stuff\n",
             kind = razor.language_kinds.html,
-            path = full_path,
+            uri = uri,
             updates = {},
             change_event = {
                 listeners = {},
@@ -146,7 +146,7 @@ describe("virtual document", function()
             {
                 previousWasEmpty = false,
                 hostDocumentVersion = 5,
-                hostDocumentFilePath = full_path,
+                hostDocumentFilePath = uri,
                 changes = {
                     {
                         newText = "i💩\n",
@@ -164,7 +164,7 @@ describe("virtual document", function()
             host_document_version = 5,
             content = "i💩\nHello in the middle stuff\n",
             kind = razor.language_kinds.html,
-            path = full_path,
+            uri = uri,
             updates = {},
             change_event = {
                 listeners = {},
@@ -175,7 +175,7 @@ describe("virtual document", function()
             {
                 previousWasEmpty = false,
                 hostDocumentVersion = 6,
-                hostDocumentFilePath = full_path,
+                hostDocumentFilePath = uri,
                 changes = {
                     {
                         newText = "",
@@ -193,7 +193,7 @@ describe("virtual document", function()
             host_document_version = 6,
             content = "Hello in the middle stuff\n",
             kind = razor.language_kinds.html,
-            path = full_path,
+            uri = uri,
             updates = {},
             change_event = {
                 listeners = {},
@@ -214,7 +214,7 @@ describe("virtual document", function()
             {
                 previousWasEmpty = false,
                 hostDocumentVersion = 7,
-                hostDocumentFilePath = full_path,
+                hostDocumentFilePath = uri,
                 changes = {
                     {
                         newText = "",
@@ -233,7 +233,7 @@ describe("virtual document", function()
             host_document_version = 7,
             content = "Hello in the middle stuff\n",
             kind = razor.language_kinds.html,
-            path = full_path,
+            uri = uri,
             updates = {},
             change_event = {
                 listeners = { update_handler },

--- a/tests/rzls/virtual_document_spec.lua
+++ b/tests/rzls/virtual_document_spec.lua
@@ -19,6 +19,7 @@ describe("virtual document", function()
             content = "",
             kind = razor.language_kinds.html,
             path = full_path,
+            updates = {},
             change_event = {
                 listeners = {},
             },
@@ -26,146 +27,174 @@ describe("virtual document", function()
     end)
 
     it("update virtual document", function()
-        vd:update_content({
-            previousWasEmpty = true,
-            hostDocumentVersion = 1,
-            hostDocumentFilePath = full_path,
-            changes = {
-                {
-                    newText = "Hello\n",
-                    span = {
-                        start = 0,
-                        length = 0,
+        vd.updates = {
+            {
+                previousWasEmpty = true,
+                hostDocumentVersion = 1,
+                hostDocumentFilePath = full_path,
+                changes = {
+                    {
+                        newText = "Hello\n",
+                        span = {
+                            start = 0,
+                            length = 0,
+                        },
                     },
                 },
             },
-        })
+        }
+        vd:update_content()
         eq({
             buf = bufnr,
             host_document_version = 1,
             content = "Hello\n",
             kind = razor.language_kinds.html,
             path = full_path,
+            updates = {},
             change_event = {
                 listeners = {},
             },
         }, vd)
-        vd:update_content({
-            previousWasEmpty = false,
-            hostDocumentVersion = 2,
-            hostDocumentFilePath = full_path,
-            changes = {
-                {
-                    newText = " World\n",
-                    span = {
-                        start = 5,
-                        length = 1,
+        vd.updates = {
+            {
+                previousWasEmpty = false,
+                hostDocumentVersion = 2,
+                hostDocumentFilePath = full_path,
+                changes = {
+                    {
+                        newText = " World\n",
+                        span = {
+                            start = 5,
+                            length = 1,
+                        },
                     },
                 },
             },
-        })
+        }
+        vd:update_content()
         eq({
             buf = bufnr,
             host_document_version = 2,
             content = "Hello World\n",
             kind = razor.language_kinds.html,
             path = full_path,
+            updates = {},
             change_event = {
                 listeners = {},
             },
         }, vd)
-        vd:update_content({
-            previousWasEmpty = false,
-            hostDocumentVersion = 3,
-            hostDocumentFilePath = full_path,
-            changes = {
-                {
-                    newText = "stuff\n",
-                    span = {
-                        start = 6,
-                        length = 6,
+
+        vd.updates = {
+            {
+                previousWasEmpty = false,
+                hostDocumentVersion = 3,
+                hostDocumentFilePath = full_path,
+                changes = {
+                    {
+                        newText = "stuff\n",
+                        span = {
+                            start = 6,
+                            length = 6,
+                        },
                     },
                 },
             },
-        })
+        }
+        vd:update_content()
         eq({
             buf = bufnr,
             host_document_version = 3,
             content = "Hello stuff\n",
             kind = razor.language_kinds.html,
             path = full_path,
+            updates = {},
             change_event = {
                 listeners = {},
             },
         }, vd)
-        vd:update_content({
-            previousWasEmpty = false,
-            hostDocumentVersion = 4,
-            hostDocumentFilePath = full_path,
-            changes = {
-                {
-                    newText = "in the middle ",
-                    span = {
-                        start = 6,
-                        length = 0,
+
+        vd.updates = {
+            {
+                previousWasEmpty = false,
+                hostDocumentVersion = 4,
+                hostDocumentFilePath = full_path,
+                changes = {
+                    {
+                        newText = "in the middle ",
+                        span = {
+                            start = 6,
+                            length = 0,
+                        },
                     },
                 },
             },
-        })
+        }
+        vd:update_content()
         eq({
             buf = bufnr,
             host_document_version = 4,
             content = "Hello in the middle stuff\n",
             kind = razor.language_kinds.html,
             path = full_path,
+            updates = {},
             change_event = {
                 listeners = {},
             },
         }, vd)
-        vd:update_content({
-            previousWasEmpty = false,
-            hostDocumentVersion = 5,
-            hostDocumentFilePath = full_path,
-            changes = {
-                {
-                    newText = "i💩\n",
-                    span = {
-                        start = 0,
-                        length = 0,
+
+        vd.updates = {
+            {
+                previousWasEmpty = false,
+                hostDocumentVersion = 5,
+                hostDocumentFilePath = full_path,
+                changes = {
+                    {
+                        newText = "i💩\n",
+                        span = {
+                            start = 0,
+                            length = 0,
+                        },
                     },
                 },
             },
-        })
+        }
+        vd:update_content()
         eq({
             buf = bufnr,
             host_document_version = 5,
             content = "i💩\nHello in the middle stuff\n",
             kind = razor.language_kinds.html,
             path = full_path,
+            updates = {},
             change_event = {
                 listeners = {},
             },
         }, vd)
-        vd:update_content({
-            previousWasEmpty = false,
-            hostDocumentVersion = 6,
-            hostDocumentFilePath = full_path,
-            changes = {
-                {
-                    newText = "",
-                    span = {
-                        start = 0,
-                        length = 3,
+
+        vd.updates = {
+            {
+                previousWasEmpty = false,
+                hostDocumentVersion = 6,
+                hostDocumentFilePath = full_path,
+                changes = {
+                    {
+                        newText = "",
+                        span = {
+                            start = 0,
+                            length = 3,
+                        },
                     },
                 },
             },
-        })
+        }
+        vd:update_content()
         eq({
             buf = bufnr,
             host_document_version = 6,
             content = "Hello in the middle stuff\n",
             kind = razor.language_kinds.html,
             path = full_path,
+            updates = {},
             change_event = {
                 listeners = {},
             },
@@ -181,20 +210,23 @@ describe("virtual document", function()
 
         local dispose_handler = vd.change_event:on(update_handler)
 
-        vd:update_content({
-            previousWasEmpty = false,
-            hostDocumentVersion = 7,
-            hostDocumentFilePath = full_path,
-            changes = {
-                {
-                    newText = "",
-                    span = {
-                        start = 0,
-                        length = 0,
+        vd.updates = {
+            {
+                previousWasEmpty = false,
+                hostDocumentVersion = 7,
+                hostDocumentFilePath = full_path,
+                changes = {
+                    {
+                        newText = "",
+                        span = {
+                            start = 0,
+                            length = 0,
+                        },
                     },
                 },
             },
-        })
+        }
+        vd:update_content()
 
         eq({
             buf = bufnr,
@@ -202,6 +234,7 @@ describe("virtual document", function()
             content = "Hello in the middle stuff\n",
             kind = razor.language_kinds.html,
             path = full_path,
+            updates = {},
             change_event = {
                 listeners = { update_handler },
             },


### PR DESCRIPTION
there have been some fairly major changes in the rzls/roslyn and vscode extension to mean that docs don't always need to be open

This is a start of supporting that