### PR TITLE
fix(documentstore): changes to roslyn handler workflow

### DIFF
--- a/lua/rzls/razor.lua
+++ b/lua/rzls/razor.lua
@@ -55,7 +55,7 @@ local M = {}
 ---@field updates? razor.DynamicFileUpdate[]
 ---@field checksum string
 ---@field checksumAlgorithm number
----@field enodingCodePage number
+---@field encodingCodePage number | vim.NIL
 
 ---@class razor.DynamicFileUpdate
 ---@field edits Change[]

--- a/lua/rzls/roslyn_handlers.lua
+++ b/lua/rzls/roslyn_handlers.lua
@@ -12,7 +12,9 @@ local function roslyn_razor_provideDynamicFileHandler(_err, result, _ctx, _confi
         return nil, vim.lsp.rpc.rpc_response_error(-32602, "Missing razorDocument")
     end
     local vd = documentstore.get_virtual_document(result.razorDocument.uri, razor.language_kinds.csharp, "any")
-    if not vd then
+    local rvd = documentstore.get_virtual_document(result.razorDocument.uri, razor.language_kinds.razor, "any")
+
+    if not vd or not rvd then
         return nil, vim.lsp.rpc.rpc_response_error(-32600, "Could not find requested document")
     end
 
@@ -20,11 +22,11 @@ local function roslyn_razor_provideDynamicFileHandler(_err, result, _ctx, _confi
         ---@type razor.ProvideDynamicFileResponse
         local resp = {
             csharpDocument = {
-                uri = vd.uri,
+                uri = rvd.uri,
             },
-            checksum = vd.checksum,
-            checksumAlgorithm = vd.checksum_algorithm,
-            enodingCodePage = vd.encoding_code_page,
+            checksum = vd.checksum or "",
+            checksumAlgorithm = vd.checksum_algorithm or 1,
+            encodingCodePage = vd.encoding_code_page or vim.NIL,
             updates = {
                 {
                     edits = {
@@ -42,23 +44,45 @@ local function roslyn_razor_provideDynamicFileHandler(_err, result, _ctx, _confi
         return resp
     end
 
-    ---@type razor.DynamicFileUpdate[]
-    local edits = vim.iter(vd.updates)
-        :map(function(v)
-            return { edits = v.changes }
-        end)
-        :totable()
-    ---@type razor.ProvideDynamicFileResponse
-    local resp = {
-        csharpDocument = {
-            uri = vd.uri,
-        },
-        checksum = vd.checksum,
-        checksumAlgorithm = vd.checksum_algorithm,
-        enodingCodePage = vd.encoding_code_page,
-        updates = not vd.buf and edits or nil,
-    }
-    return resp
+    if rvd.buf then
+        -- Open documents have didOpen/didChange to update the csharp buffer. Razor
+        --does not send edits and instead lets vscode handle them.
+        ---@type razor.ProvideDynamicFileResponse
+        local resp = {
+            csharpDocument = {
+                uri = vd.uri,
+            },
+            checksum = vd.checksum or "",
+            checksumAlgorithm = vd.checksum_algorithm or 1,
+            encodingCodePage = vd.encoding_code_page or vim.NIL,
+            updates = vim.NIL,
+        }
+        return resp
+    else
+        local updates, original_checksum, original_checksum_algorithm, original_encoding_code_page = vd:apply_edits()
+        local edits
+        if vim.tbl_isempty(updates) then
+            edits = nil
+        else
+            ---@type razor.DynamicFileUpdate[]
+            edits = vim.iter(updates)
+                :map(function(v)
+                    return { edits = v.changes }
+                end)
+                :totable()
+        end
+        ---@type razor.ProvideDynamicFileResponse
+        local resp = {
+            csharpDocument = {
+                uri = vd.uri,
+            },
+            checksum = original_checksum,
+            checksumAlgorithm = original_checksum_algorithm,
+            encodingCodePage = original_encoding_code_page,
+            updates = edits or vim.NIL,
+        }
+        return resp
+    end
 end
 
 return {

--- a/lua/rzls/roslyn_handlers.lua
+++ b/lua/rzls/roslyn_handlers.lua
@@ -15,7 +15,12 @@ local function roslyn_razor_provideDynamicFileHandler(_err, result, _ctx, _confi
     local rvd = documentstore.get_virtual_document(result.razorDocument.uri, razor.language_kinds.razor, "any")
 
     if not vd or not rvd then
-        return nil, vim.lsp.rpc.rpc_response_error(-32600, "Could not find requested document")
+        documentstore.register_vbufs_by_path(vim.uri_to_fname(result.razorDocument.uri), false)
+        vd = documentstore.get_virtual_document(result.razorDocument.uri, razor.language_kinds.csharp, "any")
+        rvd = documentstore.get_virtual_document(result.razorDocument.uri, razor.language_kinds.razor, "any")
+        if not vd or not rvd then
+            return nil, vim.lsp.rpc.rpc_response_error(-32600, "Could not find requested document")
+        end
     end
 
     if result.fullText then

--- a/lua/rzls/server/methods/definition.lua
+++ b/lua/rzls/server/methods/definition.lua
@@ -54,12 +54,14 @@ return function(params)
         elseif v.uri:match(razor.virtual_suffixes.csharp .. "$") then
             local mapped_loc = rvd:map_to_document_ranges(language_query_response.kind, { v.range })
             if mapped_loc and mapped_loc.ranges[1] then
-                ---@type lsp.Definition
-                local data = {
-                    uri = params.textDocument.uri,
-                    range = mapped_loc.ranges[1],
-                }
-                table.insert(response, data)
+                if mapped_loc.ranges[1].start.line >= 0 and mapped_loc.ranges[1]["end"].line >= 0 then
+                    ---@type lsp.Definition
+                    local data = {
+                        uri = params.textDocument.uri,
+                        range = mapped_loc.ranges[1],
+                    }
+                    table.insert(response, data)
+                end
             end
         else
             table.insert(response, v)

--- a/lua/rzls/server/methods/semantictokens_full.lua
+++ b/lua/rzls/server/methods/semantictokens_full.lua
@@ -5,7 +5,10 @@ local au = vim.api.nvim_create_augroup("rzls_semantic_tokens", {})
 vim.api.nvim_create_autocmd("WinScrolled", {
     group = au,
     callback = function(ev)
-        vim.lsp.semantic_tokens.force_refresh(ev.buf)
+        local ft = vim.api.nvim_get_option_value("filetype", { buf = ev.buf })
+        if ft == "razor" then
+            vim.lsp.semantic_tokens.force_refresh(ev.buf)
+        end
     end,
 })
 

--- a/tests/rzls/virtual_document_spec.lua
+++ b/tests/rzls/virtual_document_spec.lua
@@ -7,9 +7,7 @@ describe("virtual document", function()
     local vd
     local path = "tests/rzls/fixtures/vdtest.razor__virtual.html"
     local uri = "file://" .. vim.loop.cwd() .. "/" .. path
-    vim.cmd.edit({ args = { path } })
-    local ls = vim.fn.getbufinfo({ buflisted = 1 })
-    local bufnr = ls[1].bufnr
+    local bufnr = vim.uri_to_bufnr(uri)
 
     it("create virtual document", function()
         vd = virtual_document:new(bufnr, razor.language_kinds.html)
@@ -240,12 +238,9 @@ describe("virtual document", function()
             },
         }, vd)
 
-        -- Schedule resuming to give a change to the `update_handler` to be called
-        local co = coroutine.running()
-        vim.schedule(function()
-            coroutine.resume(co)
-        end)
-        coroutine.yield()
+        vim.wait(10000, function()
+            return update_handler_called
+        end, 250)
 
         eq(true, update_handler_called)
 


### PR DESCRIPTION
Follows issues outstanding from #38 

## outstanding
- ~~links to components dont work unless you open the component first~~
- ~~opening .cs file first~~
- ~~gd's are weird from within razor code~~