### PR TITLE
refactor(roslyn)!: change to stdio communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ to communicate with the razor LSP. To do so, you must pass the handlers defined 
 ```lua
 require('roslyn').setup {
   args = {
+    '--stdio',
     '--logLevel=Information',
     '--extensionLogDirectory=' .. vim.fs.dirname(vim.lsp.get_log_path()),
     '--razorSourceGenerator=' .. vim.fs.joinpath(
@@ -134,6 +135,7 @@ return {
     config = function()
       require('roslyn').setup {
         args = {
+          '--stdio',
           '--logLevel=Information',
           '--extensionLogDirectory=' .. vim.fs.dirname(vim.lsp.get_log_path()),
           '--razorSourceGenerator='

--- a/lua/rzls/init.lua
+++ b/lua/rzls/init.lua
@@ -68,9 +68,8 @@ function M.setup(config)
                     "true",
                 },
                 on_init = function(client, _initialize_result)
-                    ---@module "roslyn"
-                    local roslyn_pipes = require("roslyn.server").get_pipes()
-                    if roslyn_pipes[root_dir] then
+                    ---@diagnostic disable-next-line: undefined-field
+                    if _G.roslyn_initialized == true then
                         documentstore.initialize(client)
                     else
                         vim.api.nvim_create_autocmd("User", {


### PR DESCRIPTION
BREAKING CHANGE:
This requires adding the `--stdio` option to your launch settings and a version of the roslyn LSP that supports `--stdio`

rzls side of https://github.com/seblj/roslyn.nvim/pull/120