### PR TITLE
docs: update README for Mason v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,7 @@ local cmd = {}
 local roslyn_package = mason_registry.get_package("roslyn")
 if roslyn_package:is_installed() then
     vim.list_extend(cmd, {
-        "dotnet",
-        vim.fs.joinpath(roslyn_package:get_install_path(), "libexec", "Microsoft.CodeAnalysis.LanguageServer.dll"),
+        "roslyn",
         "--stdio",
         "--logLevel=Information",
         "--extensionLogDirectory=" .. vim.fs.dirname(vim.lsp.get_log_path()),
@@ -133,7 +132,7 @@ if roslyn_package:is_installed() then
 
     local rzls_package = mason_registry.get_package("rzls")
     if rzls_package:is_installed() then
-        local rzls_path = vim.fs.joinpath(rzls_package:get_install_path(), "libexec")
+        local rzls_path = vim.fn.expand("$MASON/packages/rzls/libexec")
         table.insert(
             cmd,
             "--razorSourceGenerator=" .. vim.fs.joinpath(rzls_path, "Microsoft.CodeAnalysis.Razor.Compiler.dll")


### PR DESCRIPTION
Mason v2.0.0 removed the `get_install_path()` method. Instead just using `$PATH` seems more reliable now, so we can just use executable names directly, even if they end up being `.cmd`-files. `vim.fn.expand` with `$MASON` is needed to get other arbitrary files out of the package directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the command used to launch the Roslyn language server for improved integration.
  - Adjusted the path configuration for the Razor source generator to use a standard environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->