### PR TITLE
feat(removedyanmicfileinfo): add handler

### DIFF
--- a/lua/rzls/documentstore.lua
+++ b/lua/rzls/documentstore.lua
@@ -209,6 +209,23 @@ function M.get_virtual_document(uri, type, version)
     return virtual_document
 end
 
+function M.remove_virtual_document(uri)
+    local doc = virtual_documents[uri]
+    if not doc then
+        return
+    end
+
+    if doc[razor.language_kinds.csharp].buf then
+        vim.api.nvim_buf_delete(doc[razor.language_kinds.csharp].buf, { force = true })
+    end
+
+    if doc[razor.language_kinds.html].buf then
+        vim.api.nvim_buf_delete(doc[razor.language_kinds.html].buf, { force = true })
+    end
+
+    virtual_documents[uri] = nil
+end
+
 --- Returns the razor bufnr for a given virtual buffer number
 ---@param bufnr integer
 ---@return rzls.VirtualDocument

--- a/lua/rzls/roslyn_handlers/helpers.lua
+++ b/lua/rzls/roslyn_handlers/helpers.lua
@@ -1,0 +1,10 @@
+local M = {}
+
+---@param csharp_uri string
+---@return string
+---@return integer
+function M.cs_uri_to_razor_uri(csharp_uri)
+    return csharp_uri:gsub("__virtual.cs$", "")
+end
+
+return M

--- a/lua/rzls/roslyn_handlers/init.lua
+++ b/lua/rzls/roslyn_handlers/init.lua
@@ -8,7 +8,7 @@ end
 
 return {
     ["razor/provideDynamicFileInfo"] = require("rzls.roslyn_handlers.provideDynamicFileInfo"),
-    ["razor/removeDynamicFileInfo"] = not_implemented,
+    ["razor/removeDynamicFileInfo"] = require("rzls.roslyn_handlers.removeDynamicFileInfo"),
     ["razor/mapSpans"] = require("rzls.roslyn_handlers.mapSpans"),
     ["razor/mapTextChanges"] = not_implemented,
 }

--- a/lua/rzls/roslyn_handlers/mapSpans.lua
+++ b/lua/rzls/roslyn_handlers/mapSpans.lua
@@ -1,5 +1,6 @@
 local razor = require("rzls.razor")
 local documentstore = require("rzls.documentstore")
+local helpers = require("rzls.roslyn_handlers.helpers")
 
 ---@type razor.razorMapSpansResponse
 local empty_response = {
@@ -9,13 +10,6 @@ local empty_response = {
     ranges = {},
     spans = {},
 }
-
----@param csharp_uri string
----@return string
----@return integer
-local function cs_uri_to_razor_uri(csharp_uri)
-    return csharp_uri:gsub("__virtual.cs$", "")
-end
 
 ---@param _err lsp.ResponseError
 ---@param result razor.razorMapSpansParams
@@ -27,7 +21,7 @@ return function(_err, result, _ctx, _config)
     if result.csharpDocument == nil then
         return nil, vim.lsp.rpc.rpc_response_error(-32602, "Missing csharpDocument")
     end
-    local razor_uri = cs_uri_to_razor_uri(result.csharpDocument.uri)
+    local razor_uri = helpers.cs_uri_to_razor_uri(result.csharpDocument.uri)
     local rvd = documentstore.get_virtual_document(razor_uri, razor.language_kinds.razor, "any")
     if not rvd then
         return empty_response, nil

--- a/lua/rzls/roslyn_handlers/removeDynamicFileInfo.lua
+++ b/lua/rzls/roslyn_handlers/removeDynamicFileInfo.lua
@@ -1,0 +1,13 @@
+local helpers = require("rzls.roslyn_handlers.helpers")
+local documentstore = require("rzls.documentstore")
+
+---@param _err lsp.ResponseError
+---@param result razor.RemoveDynamicFileParams
+---@param _ctx lsp.HandlerContext
+---@param _config? table
+---@return razor.ProvideDynamicFileResponse|nil
+---@return lsp.ResponseError|nil
+return function(_err, result, _ctx, _config)
+    local razor_uri = helpers.cs_uri_to_razor_uri(result.csharpDocument.uri)
+    documentstore.remove_virtual_document(razor_uri)
+end

--- a/lua/rzls/server/methods/semantictokens_full.lua
+++ b/lua/rzls/server/methods/semantictokens_full.lua
@@ -39,7 +39,7 @@ return function(params)
                 line = wininfo[1].botline - 1,
                 character = (
                     string.len(
-                        vim.api.nvim_buf_get_lines(rvd.buf, wininfo[1].botline - 1, wininfo[1].botline, false)[1]
+                        vim.api.nvim_buf_get_lines(rvd.buf, wininfo[1].botline - 1, wininfo[1].botline, false)[1] or ""
                     )
                 ),
             },


### PR DESCRIPTION
Added remove_virtual_document to clean up virtual documents by closing associated buffers. Introduced a URI conversion helper and updated dynamic file handlers for consistency.

Closes #65 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to remove virtual documents and their associated buffers for specific URIs.
  - Introduced a new handler for removing dynamic file information related to Razor files.

- **Bug Fixes**
  - Improved stability by preventing errors when calculating line lengths on potentially missing lines.

- **Refactor**
  - Centralized URI transformation logic into a shared helper module for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->