### PR TITLE
refactor: remove deprecated --forceRuntimeCodeGeneration flag

### DIFF
--- a/lua/rzls/init.lua
+++ b/lua/rzls/init.lua
@@ -72,8 +72,6 @@ function M.setup(config)
                 "true",
                 "--UpdateBuffersForClosedDocuments",
                 "true",
-                "--forceRuntimeCodeGeneration",
-                "false",
                 "--SingleServerCompletionSupport",
                 "true",
                 "--useNewFormattingEngine",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed two command-line options from the Razor LSP client startup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->