### PR TITLE
refactor: use method-call syntax for LSP notifications

### DIFF
--- a/lua/rzls/documentstore.lua
+++ b/lua/rzls/documentstore.lua
@@ -146,9 +146,7 @@ function M.update_vbuf(result, language_kind)
             end
 
             for i, notify in ipairs(roslyn_notify_queue) do
-                --=TODO: Remove when 0.11 only
-                ---@diagnostic disable-next-line: param-type-mismatch
-                roslyn.notify(razor.notification.razor_dynamicFileInfoChanged, notify)
+                roslyn:notify(razor.notification.razor_dynamicFileInfoChanged, notify)
                 roslyn_notify_queue[i] = nil
             end
         end
@@ -255,18 +253,14 @@ function M.initialize(rzls_client_id)
     local function initialize_roslyn()
         local roslyn_client = vim.lsp.get_clients({ name = "roslyn" })[1]
 
-        --=TODO: Remove when 0.11 only
-        ---@diagnostic disable-next-line: param-type-mismatch
-        roslyn_client.notify(razor.notification.razor_initialize, {
+        roslyn_client:notify(razor.notification.razor_initialize, {
             pipeName = pipe_name,
         })
 
         local rzls_client = vim.lsp.get_client_by_id(rzls_client_id)
         assert(rzls_client, "rzls client not found")
 
-        --=TODO: Remove when 0.11 only
-        ---@diagnostic disable-next-line: param-type-mismatch
-        rzls_client.notify(razor.notification.razor_namedPipeConnect, {
+        rzls_client:notify(razor.notification.razor_namedPipeConnect, {
             pipeName = pipe_name,
         })
     end

--- a/lua/rzls/virtual_document.lua
+++ b/lua/rzls/virtual_document.lua
@@ -242,8 +242,6 @@ function VirtualDocument:language_query(position)
     lsp:request("razor/languageQuery", {
         position = position,
         uri = self.uri,
-        --=TODO: Remove when 0.11 only
-        ---@diagnostic disable-next-line: param-type-mismatch
     }, function(err, result)
         if not result or err then
             Log.rzlsnvim = "Language Query Request failed: " .. vim.inspect(err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal method usage for better consistency and maintainability.
* **Style**
  * Removed outdated comments and diagnostic directives for cleaner code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->