### PR TITLE
feat(server): remove workaround for Neovim null deserialization in co…

### DIFF
--- a/lua/rzls/server/methods/codeactionresolve.lua
+++ b/lua/rzls/server/methods/codeactionresolve.lua
@@ -1,15 +1,6 @@
 local documentstore = require("rzls.documentstore")
 local razor = require("rzls.razor")
 
--- HACK: neovim does not deserialize `null`s and rzls expects an explicit `null` value
--- in the `data.delegatedDocumentUri` field of a code action.
--- This issue is being tracker here: https://github.com/neovim/neovim/issues/31368
--- We can remove code actions from aftershave when this issue is resolved.
-local code_action_required_fields = {
-    data = {
-        delegatedDocumentUri = vim.NIL,
-    },
-}
 
 ---@param code_action lsp.CodeAction
 ---@return lsp.CodeAction | nil
@@ -21,8 +12,7 @@ return function(code_action)
         return
     end
 
-    local params = vim.tbl_deep_extend("keep", code_action, code_action_required_fields)
-    local resolve, resolve_err = rvd:lsp_request(vim.lsp.protocol.Methods.codeAction_resolve, params)
+    local resolve, resolve_err = rvd:lsp_request(vim.lsp.protocol.Methods.codeAction_resolve, code_action)
 
     if resolve_err then
         vim.notify("Error resolving code action: " .. resolve_err.message, vim.log.levels.ERROR, {


### PR DESCRIPTION
…de action resolve

Remove the explicit `delegatedDocumentUri = vim.NIL` workaround