### PR TITLE
fix: textDocument/rename should apply to edits to non-virtual documents

### DIFF
--- a/lua/rzls/server/methods/rename.lua
+++ b/lua/rzls/server/methods/rename.lua
@@ -68,11 +68,8 @@ return function(params)
                 local remapped_response = rvd:map_to_document_ranges(razor.language_kinds.csharp, { edit.range })
                 if remapped_response ~= nil and remapped_response.ranges ~= nil then
                     for _, range in ipairs(remapped_response.ranges) do
-                        if range.start.line > 0 then
-                            table.insert(
-                                remapped_edits,
-                                { newText = edit.newText, range = remapped_response.ranges[1] }
-                            )
+                        if range.start.line >= 0 then
+                            table.insert(remapped_edits, { newText = edit.newText, range = range })
                         end
                     end
                 end


### PR DESCRIPTION
Edits where not being applied to `.razor` and `.cs` documents, effectively not applying any edit at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rename refactoring to correctly handle C# virtual documents by applying remapped edits only when appropriate and preserving original edits for other document types.
  * Ensures workspace rename operations now include only relevant remapped changes and retain unchanged documents, improving reliability of multi-file rename actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->